### PR TITLE
ci: allow dependabot branches to bypass branch-policy check

### DIFF
--- a/.github/workflows/enforce-feature-branch.yml
+++ b/.github/workflows/enforce-feature-branch.yml
@@ -12,6 +12,10 @@ jobs:
         shell: bash
         run: |
           branch="${{ github.head_ref }}"
+          if [[ "$branch" == dependabot/* ]]; then
+            echo "Dependabot branch — policy check skipped"
+            exit 0
+          fi
           pattern='^(feature|fix|chore|docs|refactor|test|ci|build|perf|hotfix)/[a-z0-9._-]+$'
           if [[ ! "$branch" =~ $pattern ]]; then
             echo "Invalid branch name: $branch"


### PR DESCRIPTION
**Problem:** `branch-policy` job was either missing dependabot exclusion or using `if: github.actor != 'dependabot[bot]'` which causes the job to be SKIPPED — GitHub treats a required SKIPPED check as not satisfied, blocking all Dependabot PRs.

**Fix:** Add `if [[ "$branch" == dependabot/* ]]; then exit 0; fi` inline so the job always runs and reports SUCCESS for dependabot branches.

**Impact:** Unblocks all open Dependabot PRs once merged.