### PR TITLE
chore(standards): add typecheck alias and build makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,11 @@ test: ## Run tests
 test-cov: ## Run tests with coverage report
 	pytest tests/ -v --cov=diy_stream_deck --cov-report=term-missing --cov-report=xml
 
+typecheck: type-check ## Run mypy type checking (alias for type-check)
+
+build: clean ## Build wheel distribution package
+	$(PYTHON) -m build
+
 # ─── Cleanup ──────────────────────────────────────────────────────────────────
 
 clean: ## Clean build artifacts


### PR DESCRIPTION
## Summary

Standards compliance update — adds missing mandatory Makefile targets as defined in `chrysa/shared-standards/EXECUTION_STANDARD.md §1`.

## Changes

- Add `typecheck` target (alias for existing `type-check`)
- Add `build` target (python -m build)

## Checklist
- [x] All mandatory Makefile targets now present per EXECUTION_STANDARD §1
- [x] No functional code changed