### PR TITLE
fix(diy-stream-deck): add missing build target + standards compliance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,63 +8,118 @@ on:
     push:
         branches:
             - main
-            - feature/**
-            - fix/**
+            - "feat/**"
+            - "feature/**"
+            - "fix/**"
+            - "chore/**"
+            - "ci/**"
     workflow_dispatch:
 
 permissions:
-    contents: write
     checks: write
+    contents: write
     pull-requests: write
+    statuses: write
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
 
 jobs:
-    lint:
-        name: Lint & Format
+    config:
+        name: Build matrix config
         runs-on: ubuntu-latest
-        timeout-minutes: 10
+        timeout-minutes: 5
+        outputs:
+            python-versions: ${{ steps.matrix.outputs.python-versions }}
+            latest-python: ${{ steps.matrix.outputs.latest-python }}
+        steps:
+            - id: matrix
+              shell: bash
+              run: |
+                  echo 'python-versions=["3.12","3.13","3.14"]' >> "$GITHUB_OUTPUT"
+                  echo 'latest-python=3.14' >> "$GITHUB_OUTPUT"
+
+    ruff:
+        name: Ruff (${{ matrix.python-version }})
+        needs: config
+        runs-on: ubuntu-latest
+        timeout-minutes: 15
         strategy:
+            fail-fast: false
             matrix:
-                python-version: ["3.12", "3.13"]
+                python-version: ${{ fromJson(needs.config.outputs.python-versions) }}
         steps:
             - uses: actions/checkout@v6
 
-            - uses: chrysa/github-actions/python-setup@main
+            - name: Setup environment
+              uses: chrysa/github-actions/tool-setup@v1
               with:
                   python-version: ${{ matrix.python-version }}
+                  extras: dev
 
-            - uses: chrysa/github-actions/ruff-check@main
+            - name: Ruff checks
+              uses: chrysa/github-actions/ruff-check@v1
               with:
                   python-version: ${{ matrix.python-version }}
-                  latest-python: "3.13"
+                  latest-python: ${{ needs.config.outputs.latest-python }}
                   sources: "diy_stream_deck tests"
 
-    tests:
-        name: Tests
+    mypy:
+        name: Mypy (${{ matrix.python-version }})
+        needs: config
         runs-on: ubuntu-latest
-        timeout-minutes: 10
+        continue-on-error: true
+        timeout-minutes: 20
         strategy:
+            fail-fast: false
             matrix:
-                python-version: ["3.12", "3.13"]
+                python-version: ${{ fromJson(needs.config.outputs.python-versions) }}
         steps:
             - uses: actions/checkout@v6
 
-            - uses: chrysa/github-actions/python-setup@main
+            - name: Setup environment
+              uses: chrysa/github-actions/tool-setup@v1
               with:
                   python-version: ${{ matrix.python-version }}
+                  extras: dev
 
-            - name: Install dependencies
-              run: pip install -e ".[dev]"
-
-            - uses: chrysa/github-actions/run-tests@main
+            - name: Mypy checks
+              uses: chrysa/github-actions/mypy-check@v1
               with:
                   python-version: ${{ matrix.python-version }}
-                  latest-python: "3.13"
-                  test-path: "tests/"
+                  latest-python: ${{ needs.config.outputs.latest-python }}
+                  sources: diy_stream_deck
+
+    test:
+        name: Test (${{ matrix.python-version }})
+        needs: config
+        runs-on: ubuntu-latest
+        timeout-minutes: 30
+        strategy:
+            fail-fast: false
+            matrix:
+                python-version: ${{ fromJson(needs.config.outputs.python-versions) }}
+        steps:
+            - uses: actions/checkout@v6
+
+            - name: Setup environment
+              uses: chrysa/github-actions/tool-setup@v1
+              with:
+                  python-version: ${{ matrix.python-version }}
+                  extras: dev
+
+            - name: Run tests
+              uses: chrysa/github-actions/run-tests@v1
+              with:
+                  python-version: ${{ matrix.python-version }}
+                  latest-python: ${{ needs.config.outputs.latest-python }}
+                  cov-module: diy_stream_deck
 
     sonar:
-        name: SonarCloud
-        needs: [lint, tests]
-        if: github.ref == 'refs/heads/main'
+        name: SonarCloud analysis
+        needs: [config, ruff, mypy, test]
+        if: always()
         runs-on: ubuntu-latest
         timeout-minutes: 15
         steps:
@@ -72,14 +127,14 @@ jobs:
               with:
                   fetch-depth: 0
 
-            - name: SonarCloud Scan
-              uses: SonarSource/sonarcloud-github-action@v5
-              env:
-                  SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+            - name: SonarCloud scan
+              uses: chrysa/github-actions/sonar-scan@v1
               with:
-                  args: >
-                      -Dsonar.projectKey=chrysa_diy-stream-deck
-                      -Dsonar.organization=chrysa
-                      -Dsonar.python.version=3.12,3.13
-                      -Dsonar.sources=diy_stream_deck
-                      -Dsonar.tests=tests
+                  latest-python: ${{ needs.config.outputs.latest-python }}
+                  sonar-token: ${{ secrets.SONAR_TOKEN }}
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  project-key: chrysa_diy-stream-deck
+                  organization: chrysa
+                  project-name: diy-stream-deck
+                  sources: diy_stream_deck
+                  tests: tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
             - name: Create tag
               run: |
                   git config user.name 'chrysa'
-                  git config user.email 'greau.anthony@gmail.com'
+                  git config user.email 'greau.anthony+chrysa@gmail.com'
                   git tag "${{ steps.changelog.outputs.version }}" || echo "Tag already exists"
                   git push origin "${{ steps.changelog.outputs.version }}" || echo "Tag push skipped"
 

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,60 @@
+---
+# Reusable secret scanning workflow (chrysa ecosystem)
+#
+# Usage — copy to .github/workflows/secret-scan.yml:
+#
+#   name: Secret scan
+#   on:
+#     push:
+#       branches: [main, develop, "feat/**", "fix/**", "release/**"]
+#     pull_request:
+#       branches: [main, develop]
+#   permissions:
+#     contents: read
+#   jobs:
+#     gitleaks:
+#       name: Detect secrets (Gitleaks)
+#       runs-on: ubuntu-latest
+#       steps:
+#         - uses: actions/checkout@v6
+#           with:
+#             fetch-depth: 0
+#         - uses: gitleaks/gitleaks-action@v2
+#           env:
+#             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#
+# All chrysa repos must include this workflow. No exceptions.
+# The gitleaks pre-commit hook (local) is complementary, not a substitute.
+
+name: Secret scan
+
+on:
+    push:
+        branches:
+            - main
+            - develop
+            - "feat/**"
+            - "feature/**"
+            - "fix/**"
+            - "release/**"
+    pull_request:
+        branches:
+            - main
+            - develop
+            - master
+
+permissions:
+    contents: read
+
+jobs:
+    gitleaks:
+        name: Detect secrets (Gitleaks)
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v6
+              with:
+                  fetch-depth: 0
+
+            - uses: gitleaks/gitleaks-action@v2
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -7,7 +7,7 @@ branches:
     main:
         regex: ^main$
     feature:
-        regex: ^feature/.*$
+        regex: ^(feature|feat)/.*$
         increment: Minor
     fix:
         regex: ^fix/.*$

--- a/Makefile
+++ b/Makefile
@@ -65,3 +65,6 @@ typecheck: ## Alias → type-check
 	@$(MAKE) type-check
 
 
+
+build: ## Build Docker image
+	docker compose build

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ test: ## Run tests
 	pytest tests/ -v
 
 test-cov: ## Run tests with coverage report
-	pytest tests/ -v --cov=diy_stream_deck --cov-report=term-missing --cov-report=xml
+	pytest tests/ -v --cov=diy_stream_deck --cov-report=term-missing --cov-report=xml --cov-fail-under=85
 
 # ─── Cleanup ──────────────────────────────────────────────────────────────────
 

--- a/Makefile
+++ b/Makefile
@@ -58,3 +58,10 @@ clean: ## Clean build artifacts
 	find . -type f -name "*.pyc" -delete
 	find . -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
 	rm -rf .pytest_cache .mypy_cache .coverage coverage.xml dist build
+
+# ─── Compat aliases ───────────────────────────────────────────────────────────
+
+typecheck: ## Alias → type-check
+	@$(MAKE) type-check
+
+

--- a/diy_stream_deck/__main__.py
+++ b/diy_stream_deck/__main__.py
@@ -11,8 +11,8 @@ def main() -> int:
     parser.add_argument("--dry-run", action="store_true", help="Validate config without running")
     args = parser.parse_args()
 
-    print(f"DIY Stream Deck — config: {args.config}")
-    print("Not yet implemented — see roadmap in README.md")
+    print(f"DIY Stream Deck — config: {args.config}")  # noqa: T201
+    print("Not yet implemented — see roadmap in README.md")  # noqa: T201
     return 0
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -6,7 +6,7 @@ import sys
 
 def test_main_no_args_fails():
     """Running without args should exit with non-zero."""
-    result = subprocess.run(
+    result = subprocess.run(  # noqa: S603
         [sys.executable, "-m", "diy_stream_deck"],
         capture_output=True,
         text=True,
@@ -18,7 +18,7 @@ def test_main_dry_run(tmp_path):
     """Running with --dry-run and a missing config should not crash the import."""
     config = tmp_path / "test.yml"
     config.write_text("device:\n  type: virtual\n")
-    result = subprocess.run(
+    result = subprocess.run(  # noqa: S603
         [sys.executable, "-m", "diy_stream_deck", "--config", str(config), "--dry-run"],
         capture_output=True,
         text=True,


### PR DESCRIPTION
## Summary

Remaining compliance fix: adds the missing `build` target to Makefile.

## Changes
- `Makefile`: add `build: docker compose build` target (mandatory per EXECUTION_STANDARD.md)
- Includes previous commits: T201/S603 ruff silenced, feat/ GitVersion pattern, email fix, mandatory CI workflows