### PR TITLE
chore(standards): uniformize Python version and tooling config

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,35 @@
+concurrency:
+  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{ github.ref }}
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    name: Auto-merge Dependabot PR
+    runs-on: ubuntu-latest
+    steps:
+    - id: metadata
+      name: Fetch Dependabot metadata
+      uses: dependabot/fetch-metadata@v3
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+    - continue-on-error: true
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PR_URL: ${{ github.event.pull_request.html_url }}
+      name: Approve PR
+      run: gh pr review --approve "$PR_URL"
+    - env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PR_URL: ${{ github.event.pull_request.html_url }}
+      name: "Enable auto-merge (squash \u2014 waits for CI)"
+      run: gh pr merge --auto --squash "$PR_URL"
+name: Dependabot Auto-merge
+on:
+  pull_request_target:
+    types:
+    - opened
+    - reopened
+    - synchronize
+permissions:
+  contents: write
+  pull-requests: write

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,36 @@
+on:
+  push:
+    branches:
+    - main
+    paths:
+    - docs/**
+    - mkdocs.yml
+  workflow_dispatch: null
+concurrency:
+  cancel-in-progress: false
+  group: pages-${{ github.ref }}
+jobs:
+  pages:
+    name: Build and deploy docs
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - name: Set up Python 3.14
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.14'
+    - name: Install MkDocs
+      run: pip install mkdocs-material
+    - name: Build site
+      run: mkdocs build
+    - name: Deploy to GitHub Pages
+      uses: peaceiris/actions-gh-pages@v4
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: site
+    timeout-minutes: 10
+name: "GitHub Pages \u2014 Documentation"
+permissions:
+  contents: write
+  id-token: write
+  pages: write

--- a/.github/workflows/quality-gate-check.yml
+++ b/.github/workflows/quality-gate-check.yml
@@ -1,0 +1,77 @@
+on:
+  pull_request:
+    branches:
+      - develop
+      - main
+      - master
+    types:
+      - opened
+      - reopened
+      - synchronize
+  push:
+    branches:
+      - main
+      - master
+jobs:
+  quality-gate:
+    name: No-Regression Quality Gates
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+      - continue-on-error: true
+        name: Set up Node.js (if needed)
+        uses: actions/setup-node@v6
+        with:
+          cache: npm
+          node-version: "20"
+      - name: Install dependencies
+        run:
+          "if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
+          if [ -f package.json ]; then npm ci; fi
+
+          "
+      - id: quality-gate
+        name: Run quality gate verification
+        run: |
+          if [ ! -f .quality-gate-baseline.json ]; then
+            echo "ℹ️ No baseline found — skipping quality gate (run quality-gate-baseline on main first)"
+            exit 0
+          fi
+          make quality-gate-verify || exit_code=$?
+          exit "${exit_code:-0}"
+
+      - if: always()
+        name: Report quality gate status
+        run:
+          "if [ ${{ steps.quality-gate.outcome }} == 'success' ]; then\n  echo \"\
+          \u2705 All quality gates passed\"\n  exit 0\nelse\n  echo \"\u274C Quality\
+          \ gate regression detected\"\n  exit 1\nfi\n"
+      - env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OUTCOME: ${{ steps.quality-gate.outcome }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        if: always()
+        name: Set quality-gate commit status
+        run: |
+          STATE="success"
+          DESCRIPTION="All quality gates passed"
+          if [ "$OUTCOME" != "success" ]; then
+            STATE="failure"
+            DESCRIPTION="Quality gate regression detected"
+          fi
+          gh api "repos/${REPO}/statuses/${SHA}" \
+            -f state="${STATE}" \
+            -f context="quality-gate" \
+            -f description="${DESCRIPTION}"
+name: Quality Gate Check
+permissions:
+  checks: write
+  contents: read
+  statuses: write

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ fail_fast: false
 minimum_pre_commit_version: 4.1.0
 repos:
     - repo: https://github.com/chrysa/pre-commit-tools
-      rev: 0.1.0
+      rev: v0.1.1-73
       hooks:
           - id: ruff-check
           - id: ruff-format-check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 ---
 default_language_version:
-  python: python3
+  python: python3.14
 fail_fast: false
 minimum_pre_commit_version: 4.1.0
 repos:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [tool.ruff]
-target-version = "py312"
-line-length = 100
+target-version = "py314"
+line-length = 120
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "UP", "S", "B", "A", "C4", "T20"]
 ignore = ["S101"]
 
 [tool.mypy]
-python_version = "3.12"
+python_version = "3.14"
 strict = true
 ignore_missing_imports = true
 
@@ -16,20 +16,17 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
+addopts = "--cov=diy_stream_deck --cov-report=xml --cov-report=term-missing --cov-fail-under=85"
 
 [tool.coverage.run]
 source = ["diy_stream_deck"]
 omit = ["tests/*"]
 
-[tool.coverage.report]
-fail_under = 60
-show_missing = true
-
 [project]
 name = "diy-stream-deck"
 version = "0.1.0"
 description = "DIY Stream Deck alternative compatible with Linux and Windows"
-requires-python = ">=3.12"
+requires-python = ">=3.14"
 dependencies = [
     "pyyaml>=6.0",
     "requests>=2.32",


### PR DESCRIPTION
## Summary

Uniformize configuration across all active Python repos:

- **Python version**: `py312` → `py314` in `ruff.target-version`, `mypy.python_version`, `requires-python`
- **pre-commit**: set explicit `python3.14` in `default_language_version` + add missing `minimum_pre_commit_version: 4.1.0`
- **ruff**: `line-length` normalized to 120
- **pytest**: add `--cov-fail-under=85` where missing
- **workflows**: add missing standard CI workflows

Refs: chrysa/shared-standards EXECUTION_STANDARD §4