### PR TITLE
ci: centralize sonar scanning via chrysa/github-actions/sonar-scan@v1

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,35 +1,39 @@
+---
 name: SonarCloud Analysis
 
 on:
-    push:
-        branches: [main, master, develop]
-    pull_request:
-        types: [opened, synchronize, reopened]
+  push:
+    branches: [main, master, develop]
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 permissions:
-    contents: read
-    pull-requests: read
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-    sonar:
-        if: ${{ github.event_name != 'pull_request' || github.actor != 'dependabot[bot]' }}
-        name: SonarCloud scan
-        runs-on: ubuntu-latest
-        timeout-minutes: 15
-        steps:
-            - uses: actions/checkout@v4
-              with:
-                  fetch-depth: 0
-            - name: SonarCloud scan
-              uses: SonarSource/sonarqube-scan-action@v4.2.1
-              with:
-                  args: >
-                      -Dsonar.projectKey=chrysa_diy-stream-deck
-                      -Dsonar.organization=chrysa
-                      -Dsonar.projectName=diy-stream-deck
-                      -Dsonar.sources=.
-                      -Dsonar.exclusions=**/.git/**,**/reports/**,**/.vscode/**,**/node_modules/**,**/__pycache__/**,**/dist/**,**/.mypy_cache/**
-                      -Dsonar.sourceEncoding=UTF-8
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+  sonar:
+    if: github.actor != 'dependabot[bot]'
+    name: SonarCloud scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: SonarCloud scan
+        uses: chrysa/github-actions/sonar-scan@v1
+        with:
+          latest-python: "3.14"
+          sonar-token: ${{ secrets.SONAR_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          project-key: chrysa_diy-stream-deck
+          organization: chrysa
+          project-name: diy-stream-deck
+          sources: .
+          tests: tests

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -21,7 +21,7 @@ jobs:
               with:
                   fetch-depth: 0
             - name: SonarCloud scan
-              uses: SonarSource/sonarqube-scan-action@v8.0.0
+              uses: SonarSource/sonarqube-scan-action@v4.2.1
               with:
                   args: >
                       -Dsonar.projectKey=chrysa_diy-stream-deck


### PR DESCRIPTION
Migrate `sonar.yml` to use the centralized `chrysa/github-actions/sonar-scan@v1` composite action instead of inline `SonarSource/sonarqube-scan-action`.

## Changes
- Replace inline `SonarSource/sonarqube-scan-action` call with `chrysa/github-actions/sonar-scan@v1`
- Add `concurrency` block to cancel duplicate runs
- Standardize trigger branches and `if: github.actor != 'dependabot[bot]'` condition
- Bump `actions/checkout` to `@v6`

## Related
Part of ecosystem-wide CI centralization.