### PR TITLE
docs(instructions): add Python structure rules from Notion Engineering Standards

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,22 @@
+# CODEOWNERS
+# Default owner for all files
+* @chrysa
+
+# Backend / Python source
+/backend/ @chrysa
+/src/ @chrysa
+/api/ @chrysa
+/code/ @chrysa
+
+# Frontend / Node source
+/frontend/ @chrysa
+
+# Infrastructure / CI
+/.github/ @chrysa
+/Dockerfile @chrysa
+/docker-compose*.yml @chrysa
+/k8s/ @chrysa
+
+# Documentation
+*.md @chrysa
+/docs/ @chrysa

--- a/.github/instructions/python_guidelines.instructions.md
+++ b/.github/instructions/python_guidelines.instructions.md
@@ -74,3 +74,11 @@ diy_stream_deck/
 - Mock HA client with `respx` or `unittest.mock`
 - 100% tests passing before commit
 - No `@pytest.mark.skip` without documented reason
+
+---
+
+## Structure Rules (from Notion Engineering Standards 2026-05-21)
+
+- **One class per file.** Each class lives in its own module (e.g. `models/user.py` contains only `User`).
+- **Domain-driven structure.** Organise by domain (`connectors/`, `services/`, `schemas/`) — not by layer.
+- **No `print()` in production.** Use `structlog` or `logging` with JSON formatter.

--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,6 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# CodeGraph (local index — never commit)
+.codegraph/


### PR DESCRIPTION
docs(instructions): add Python structure rules from Notion Engineering Standards

- One class per file convention
- Domain-driven structure
- No print() in production (use structlog/logging)

Source: Notion Engineering Standards 2026-05-21