### PR TITLE
fix(lint): remove inline T201 suppressions in __main__.py

### DIFF
--- a/diy_stream_deck/__main__.py
+++ b/diy_stream_deck/__main__.py
@@ -11,8 +11,8 @@ def main() -> int:
     parser.add_argument("--dry-run", action="store_true", help="Validate config without running")
     args = parser.parse_args()
 
-    print(f"DIY Stream Deck — config: {args.config}")  # noqa: T201
-    print("Not yet implemented — see roadmap in README.md")  # noqa: T201
+    print(f"DIY Stream Deck — config: {args.config}")
+    print("Not yet implemented — see roadmap in README.md")
     return 0
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,9 @@ line-length = 120
 select = ["E", "F", "W", "I", "UP", "S", "B", "A", "C4", "T20"]
 ignore = ["S101"]
 
+[tool.ruff.lint.per-file-ignores]
+"diy_stream_deck/__main__.py" = ["T201"]  # print is intentional in CLI entrypoint stub
+
 [tool.mypy]
 python_version = "3.14"
 strict = true


### PR DESCRIPTION
## Summary

Removes the 2 `# noqa: T201` inline suppressions from `diy_stream_deck/__main__.py`.

## Root Cause

The `T201` rule flags `print()` calls. In this CLI entrypoint stub, print output is intentional — it is the user-facing output of the command-line tool placeholder.

## Fix

Moved `T201` to `[tool.ruff.lint.per-file-ignores]` in `pyproject.toml` scoped to `diy_stream_deck/__main__.py`.