### PR TITLE
ci(secret-scan): use reusable workflow (fixes gitleaks 403 perms)

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,28 +1,16 @@
-on:
-  pull_request:
-    branches:
-    - develop
-    - main
-    - master
-  push:
-    branches:
-    - develop
-    - feat/**
-    - feature/**
-    - fix/**
-    - main
-    - release/**
-jobs:
-  gitleaks:
-    name: Detect secrets (Gitleaks)
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-    - env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      uses: gitleaks/gitleaks-action@v2
+---
 name: Secret scan
+
+on:
+    push:
+        branches: [main, develop, "feat/**", "feature/**", "fix/**", "release/**"]
+    pull_request:
+        branches: [main, develop, master]
+
 permissions:
-  contents: read
+    contents: read
+    pull-requests: read
+
+jobs:
+    call:
+        uses: chrysa/github-actions/.github/workflows/secret-scan.yml@main


### PR DESCRIPTION
## What
Replace the vendored standalone `secret-scan.yml` with a call to the reusable `chrysa/github-actions/.github/workflows/secret-scan.yml@main`.

## Why
The standalone copy declared `permissions: contents: read` only, so `gitleaks-action@v2` got a **403** listing PR commits, failing the *Detect secrets* check on every PR. The reusable workflow now grants `pull-requests: read` (chrysa/github-actions#98) and is the single source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)