### PR TITLE
fix(tooling): work around ruff py314 formatter bug + repair corrupted except clauses

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [tool.ruff]
-target-version = "py314"
+# py313 (not py314): ruff format <=0.15.15 strips multi-except parens under py314 — restore when fixed upstream
+target-version = "py313"
 line-length = 120
 
 [tool.ruff.lint]


### PR DESCRIPTION
## Problem

`ruff format` (0.15.12 through 0.15.15) has a bug under `target-version = "py314"`: it strips the parentheses from multi-exception except clauses, e.g.

```python
except (TypeError, ValueError):  ->  except TypeError, ValueError:
```

which is invalid Python 3 syntax (`SyntaxError: multiple exception types must be parenthesized`). `py313` is unaffected and formats identically otherwise.

## Fix

- **pyproject.toml**: pin `[tool.ruff] target-version` from `py314` to `py313`, with a comment to restore once fixed upstream.

## Repaired except clauses

An AST sweep of all `*.py` found **no** corrupted except clauses in this repo, so no source files needed repair. The sweep is clean (zero syntax errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)