### PR TITLE
chore(makefile): declare tier (lib) and drop legacy type-check alias

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 #!make
+# makefile-tier: lib
 ifneq (,)
 	$(error This Makefile requires GNU Make)
 endif
@@ -44,7 +45,6 @@ format: ## Run ruff formatter
 typecheck: ## Run mypy type checking
 	mypy diy_stream_deck/
 
-type-check: typecheck ## Legacy alias
 
 # ─── Tests ────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Declare `# makefile-tier: lib` and remove the legacy `type-check` alias. The canonical target name is `typecheck` (shared-standards EXECUTION_STANDARD.md §1.4).

Part of the Makefile uniformization campaign (Phase C). Enforced by the `makefile-check` hook (pre-commit-tools #200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)