### PR TITLE
chore(config): normalize repo to chrysa standard

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,47 @@
+# Normalize line endings: treat all text as text, check out/in with LF.
+* text=auto eol=lf
+
+# Explicit text types
+*.py      text
+*.pyi     text
+*.md      text
+*.txt     text
+*.cfg     text
+*.ini     text
+*.toml    text
+*.yaml    text
+*.yml     text
+*.json    text
+*.js      text
+*.jsx     text
+*.ts      text
+*.tsx     text
+*.css     text
+*.html    text
+*.sh      text eol=lf
+Makefile  text
+Dockerfile text
+
+# Lockfiles & generated artefacts: keep diffs collapsed, exclude from language stats
+uv.lock           linguist-generated=true -diff
+poetry.lock       linguist-generated=true -diff
+package-lock.json linguist-generated=true -diff
+pnpm-lock.yaml    linguist-generated=true -diff
+yarn.lock         linguist-generated=true -diff
+
+# Binary assets — never normalize
+*.png   binary
+*.jpg   binary
+*.jpeg  binary
+*.gif   binary
+*.webp  binary
+*.ico   binary
+*.pdf   binary
+*.svg   binary
+*.woff  binary
+*.woff2 binary
+*.ttf   binary
+*.eot   binary
+*.zip   binary
+*.gz    binary
+*.db    binary

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: ruff-format
 
   - repo: https://github.com/chrysa/pre-commit-tools
-    rev: v0.1.1-92
+    rev: v0.1.1-93
     hooks:
       - id: python-unreachable-code
       - id: no-bare-except
@@ -23,6 +23,13 @@ repos:
       - id: debugger-detection
       - id: regression-gate
         stages: [pre-push]
+      - exclude: ^(\.github/|workflows/|templates/)
+        id: yaml-sorter
+      - id: json-sorter
+      - id: env-file-check
+      - id: env-example-sync
+      - id: no-hardcoded-localhost
+        exclude: 'tests?/|\.test\.|\.spec\.'
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
@@ -50,3 +57,15 @@ repos:
       - id: conventional-pre-commit
         stages: [commit-msg]
         args: [feat, fix, docs, style, refactor, test, chore, perf, revert, ci]
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.48.0
+    hooks:
+      - args:
+          - --fix
+        id: markdownlint
+        stages:
+          - manual
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.0
+    hooks:
+      - id: gitleaks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+# Contributing to diy-stream-deck
+
+Thanks for contributing. This repo follows the chrysa
+[Execution Standard](https://github.com/chrysa/shared-standards/blob/main/EXECUTION_STANDARD.md).
+
+## Prerequisites
+
+Install dev dependencies and pre-commit hooks:
+
+```bash
+make install
+```
+
+## Workflow
+
+1. **Branch** from `main` using a typed prefix: `feat/`, `fix/`, `chore/`,
+   `docs/`, `ci/`, `refactor/`, `test/`, `perf/`. Direct commits to `main` are
+   blocked (`no-commit-to-branch`).
+2. **Develop** using the `make` targets only — never call `pytest` / `ruff` /
+   `mypy` directly on the host: `make test`, `make test-cov`, `make lint`,
+   `make format`, `make typecheck`.
+3. **Commit** using [Conventional Commits](https://www.conventionalcommits.org/):
+   `type(scope): subject` (allowed types: feat, fix, docs, style, refactor, test,
+   chore, perf, revert, ci). Commit messages are linted via `conventional-pre-commit`.
+4. **Verify** before pushing, then open a PR against `main`.
+
+Verification commands:
+
+```bash
+pre-commit run --all-files
+make test
+```
+
+CI (pre-commit, lint, test, sonar) must pass and one approval is required before merge.
+
+## Code standards
+
+- All committed files (code, comments, docs, config) are in **English**.
+- No hardcoded secrets — use env vars and keep `.env.example` in sync.
+- New behaviour ships with tests; keep coverage at or above the project threshold.
+
+## Reporting issues
+
+Use the issue templates under `.github/ISSUE_TEMPLATE/`. Include reproduction
+steps, expected vs actual behaviour, and environment details.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 chrysa
+Copyright (c) 2026 Anthony Gréau
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Normalization wave (OPS-190, driven by shared-standards#84).

- **NEW** .editorconfig, .gitattributes, CONTRIBUTING.md
- **Pre-commit §8 upgrade** (gitleaks, conventional-pre-commit, no-commit-to-branch, chrysa/pre-commit-tools; non-applicable stack hooks excluded)
- dependabot + process-workflow refresh
- CI template not applied in this wave (--no-ci)

🤖 Generated with [Claude Code](https://claude.com/claude-code)