### PR TITLE
ci(pre-commit): wire makefile-check hook (v0.1.1-94)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,8 +11,9 @@ repos:
       - id: ruff-format
 
   - repo: https://github.com/chrysa/pre-commit-tools
-    rev: v0.1.1-93
+    rev: v0.1.1-94
     hooks:
+    - id: makefile-check
       - id: python-unreachable-code
       - id: no-bare-except
       - id: adr-gate


### PR DESCRIPTION
Wire the `makefile-check` hook (pre-commit-tools v0.1.1-94) into pre-commit, enforcing the archetype-tiered Makefile contract (shared-standards EXECUTION_STANDARD.md §1). Bumps the pre-commit-tools rev to v0.1.1-94 (additive only — no existing hook changed) and adds `- id: makefile-check`.

Completes the Makefile uniformization campaign (Phase C): the contract is now enforced on every commit touching a Makefile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)