### PR TITLE
ci: pin chrysa/github-actions reusable workflows to @v1.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
     ci:
-        uses: chrysa/github-actions/.github/workflows/ci-python-app.yml@main
+        uses: chrysa/github-actions/.github/workflows/ci-python-app.yml@v1.2.0
         with:
             sources: "."
             typecheck-paths: diy_stream_deck

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -11,4 +11,4 @@ concurrency:
 
 jobs:
     call:
-        uses: chrysa/github-actions/.github/workflows/dependabot-auto-merge.yml@main
+        uses: chrysa/github-actions/.github/workflows/dependabot-auto-merge.yml@v1.2.0

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -13,4 +13,4 @@ permissions:
 
 jobs:
     call:
-        uses: chrysa/github-actions/.github/workflows/secret-scan.yml@main
+        uses: chrysa/github-actions/.github/workflows/secret-scan.yml@v1.2.0


### PR DESCRIPTION
Pins all `chrysa/github-actions/.github/workflows/*.yml` references from `@main` to release tag `@v1.2.0` (verified to expose every referenced workflow). Addresses the **Pin GitHub Actions** item of the Standards compliance backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)