### PR TITLE
chore: adopt canonical GitVersion.yml (ContinuousDeployment)

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,12 +1,26 @@
 branches:
+  chore:
+    increment: Patch
+    mode: ContinuousDeployment
+    regex: ^chore/
+    tag: alpha
   feature:
     increment: Minor
-    regex: ^(feature|feat)/.*$
+    mode: ContinuousDeployment
+    regex: ^feat/
+    tag: alpha
   fix:
     increment: Patch
-    regex: ^fix/.*$
+    mode: ContinuousDeployment
+    regex: ^fix/
+    tag: beta
   main:
+    increment: Patch
+    mode: ContinuousDelivery
     regex: ^main$
-mode: semantic
-next-version-bump-type: Minor
-version: 0
+    tag: ''
+increment: Inherit
+major-version-bump-message: ^(feat|fix|refactor)(\(.+\))?!:.+
+minor-version-bump-message: ^feat(\(.+\))?:.+
+mode: ContinuousDeployment
+patch-version-bump-message: ^(fix|refactor|perf|docs|chore)(\(.+\))?:.+


### PR DESCRIPTION
Align GitVersion with canonical chrysa ContinuousDeployment config. Cosmetic-drift tail of the release-config fan-out. Refs chrysa/shared-standards#127