### PR TITLE
chore: sync chrysa shared standards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,9 +74,9 @@ jobs:
                   python-version: "3.14"
                   sonar-token: ${{ secrets.SONAR_TOKEN }}
                   github-token: ${{ secrets.GITHUB_TOKEN }}
-                  project-key: chrysa_diy-stream-deck
+                  project-key: chrysa_target
                   organization: chrysa
-                  project-name: diy-stream-deck
-                  sources: diy_stream_deck
+                  project-name: target
+                  sources: .
                   tests: tests
                   coverage-report: coverage.xml


### PR DESCRIPTION
Automated distribution of chrysa shared standards.

**Source:** `chrysa/shared-standards@7a52cde58ca2678dbc6658a52c9d375d6311a745`
Managed files (transverse `CLAUDE.md` import, `.chrysa/STANDARDS.md`,
shared skills/agents/commands, CI workflows, lint/quality, pre-commit)
were refreshed by `scripts/distribute-standards.sh`.

Review the diff: repo-specific content is preserved; only managed,
delimited blocks and shared files are updated.

Refs: chrysa/shared-standards