### PR TITLE
fix(ci): correct Sonar project key + bump scanner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,9 +74,9 @@ jobs:
                   python-version: "3.14"
                   sonar-token: ${{ secrets.SONAR_TOKEN }}
                   github-token: ${{ secrets.GITHUB_TOKEN }}
-                  project-key: chrysa_target
+                  project-key: chrysa_diy-stream-deck
                   organization: chrysa
-                  project-name: target
-                  sources: .
+                  project-name: diy-stream-deck
+                  sources: diy_stream_deck
                   tests: tests
                   coverage-report: coverage.xml


### PR DESCRIPTION
Sonar used placeholder `chrysa_target` + `sonar-scan-python@v1.0.12` (no disjoint source/test logic) -> tests indexed twice (exit 3). Fix: key `chrysa_diy-stream-deck` + bump `@v1.1.3`.

Generated with Claude Code