### PR TITLE
chore: sync chrysa shared standards

### DIFF
--- a/.claude/skills/dockerfile-multistage/SKILL.md
+++ b/.claude/skills/dockerfile-multistage/SKILL.md
@@ -85,3 +85,35 @@ build-all:
 - Installer pip dans le stage `production`
 - Créer ou activer un venv (`virtualenv`, `python -m venv`, `pip install --user`)
 - Copier `pyproject.toml`/`setup.py` dans `production`
+
+## Private chrysa-lib distribution fetch (D-0004)
+
+A package that depends on a private `chrysa-lib` distribution via a `git+https` pin
+(e.g. `chrysa-codegen @ git+https://github.com/chrysa/chrysa-lib@<sha>#subdirectory=...`)
+cannot install in a vanilla Docker build: pip shells out to `git`, which has no credential
+and fails with `could not read Username for 'https://github.com'`.
+
+Per chrysa-lib `DECISIONS.md` D-0004, fetch the private dependency with a BuildKit secret —
+never an `ARG`/`ENV`/`COPY` (those persist the token in an image layer).
+
+`Dockerfile.test`:
+```dockerfile
+# syntax=docker/dockerfile:1
+RUN --mount=type=secret,id=ghtoken,required=true \
+    git config --global url."https://x-access-token:$(cat /run/secrets/ghtoken)@github.com/".insteadOf "https://github.com/" \
+ && pip install --no-cache-dir -e ".[dev]" \
+ && rm -f /root/.gitconfig
+```
+The token is mounted (never written to a layer); the `rm -f /root/.gitconfig` in the same
+`RUN` guarantees the rewritten URL (which embeds the token) does not survive in the layer.
+
+`make docker-test` target:
+```makefile
+docker-test: ## Run tests in Docker (CI parity; private dep fetch via D-0004 BuildKit secret)
+	GH_TOKEN="$${GH_TOKEN:-$${GITHUB_TOKEN:-$$(gh auth token 2>/dev/null)}}" \
+		DOCKER_BUILDKIT=1 docker build -f Dockerfile.test --secret id=ghtoken,env=GH_TOKEN -t <image>-test .
+	docker run --rm <image>-test
+```
+Local dev resolves the token from `gh auth token`; CI passes its `GH_TOKEN`/`GITHUB_TOKEN`.
+Defer to a private PyPI index when a private distribution reaches >=3 consumers or needs
+independent semver (D-0004 revisit trigger).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,8 @@
 #   diy_stream_deck      import package / source dir       (e.g. django_pytest)
 #   diy_stream_deck tests      ruff sources, space-separated     (e.g. "django_pytest tests")
 #   tests        test dir                          (e.g. tests)
-#   target    repo name                         (e.g. django-pytest)
-#   chrysa_target  SonarCloud project key            (e.g. chrysa_django-pytest)
+#   diy-stream-deck    repo name                         (e.g. django-pytest)
+#   chrysa_diy-stream-deck  SonarCloud project key            (e.g. chrysa_django-pytest)
 #
 # ⚠️ This file lives in workflows/ (NOT .github/workflows/) — it is a copy-to-use
 #    template, not a reusable `uses:` workflow.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to target
+# Contributing to diy-stream-deck
 
 Thanks for contributing. This repo follows the chrysa
 [Execution Standard](https://github.com/chrysa/shared-standards/blob/main/EXECUTION_STANDARD.md).


### PR DESCRIPTION
Automated distribution of chrysa shared standards.

**Source:** `chrysa/shared-standards@2c115d45413e789dada354a4f68f559688f186d0`
Managed files (transverse `CLAUDE.md` import, `.chrysa/STANDARDS.md`,
shared skills/agents/commands, CI workflows, lint/quality, pre-commit)
were refreshed by `scripts/distribute-standards.sh`.

Review the diff: repo-specific content is preserved; only managed,
delimited blocks and shared files are updated.

Refs: chrysa/shared-standards