### PR TITLE
ci(pre-commit): exclude .claude/ from all hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,8 @@ default_language_version:
   python: python3.14
 fail_fast: false
 minimum_pre_commit_version: 4.1.0
+exclude: ^\.claude/
+
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.15.21


### PR DESCRIPTION
Exclude vendored .claude/ tooling from pre-commit so it stops blocking unrelated PRs. Mirrors chrysa/standards#8.