### PR TITLE
chore: sync chrysa shared standards

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,8 +32,9 @@ repos:
   - id: claude-skill-frontmatter
   - id: claude-agent-frontmatter
   - id: claude-mcp-config
+  - id: python-no-unittest-import
   repo: https://github.com/chrysa/pre-commit-tools
-  rev: v0.1.1-98
+  rev: v0.1.1-99
 - hooks:
   - id: detect-private-key
   - id: no-commit-to-branch


### PR DESCRIPTION
Automated distribution of chrysa shared standards.

**Source:** `chrysa/shared-standards@3e0544cb43c47b184d9b5a9a6a2961e77038abe7`
Managed files (inline transverse standards block in `CLAUDE.md`,
shared skills/agents/commands, CI workflows, lint/quality, pre-commit)
were refreshed by `scripts/distribute-standards.sh`.

Review the diff: repo-specific content is preserved; only managed,
delimited blocks and shared files are updated.

Refs: chrysa/shared-standards