### PR TITLE
chore: bump guideline-checker to v1.30.10

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -93,4 +93,4 @@ repos:
     - .guideline-baseline.json
     id: guideline-check
   repo: https://github.com/chrysa/guideline-checker
-  rev: v1.15.4
+  rev: v1.30.10


### PR DESCRIPTION
Bumps the guideline-checker pre-commit pin `v1.15.4` -> `v1.30.10`. Clears the fleet-wide false positive where the canonical 'no executable runtime' bullet was misread as a 'no exec()' rule and flagged every RegExp.exec()/.eval() call (chrysa/guideline-checker#305).