### PR TITLE
fix(hooks): guard claude hook commands against missing hook files

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -20,13 +20,13 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node .claude/hooks/secret-scanner.cjs",
+            "command": "sh -c 'f=\"$CLAUDE_PROJECT_DIR/.claude/hooks/secret-scanner.cjs\"; [ ! -f \"$f\" ] || node \"$f\"'",
             "name": "secret-scanner",
             "timeout": 10000
           },
           {
             "type": "command",
-            "command": "node .claude/hooks/circuit-breaker.cjs",
+            "command": "sh -c 'f=\"$CLAUDE_PROJECT_DIR/.claude/hooks/circuit-breaker.cjs\"; [ ! -f \"$f\" ] || node \"$f\"'",
             "name": "circuit-breaker",
             "timeout": 5000
           }
@@ -48,7 +48,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node .claude/hooks/verifiable-thresholds.cjs",
+            "command": "sh -c 'f=\"$CLAUDE_PROJECT_DIR/.claude/hooks/verifiable-thresholds.cjs\"; [ ! -f \"$f\" ] || node \"$f\"'",
             "name": "verifiable-thresholds",
             "timeout": 10000
           }
@@ -60,7 +60,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node .claude/hooks/frustration-detection.cjs",
+            "command": "sh -c 'f=\"$CLAUDE_PROJECT_DIR/.claude/hooks/frustration-detection.cjs\"; [ ! -f \"$f\" ] || node \"$f\"'",
             "name": "frustration-detection",
             "timeout": 5000
           }


### PR DESCRIPTION
A hook command written as a bare `node .claude/hooks/<hook>.cjs` makes Node exit with
`MODULE_NOT_FOUND` whenever the hook file is absent from the repo. Claude Code then reports,
on every single tool call:

```
PreToolUse:Bash hook error
Failed with non-blocking status code: node:internal/modules/cjs/loader:1520
```

Fix: use the guarded form for every hook command, so a missing hook file becomes a silent
no-op and the path no longer depends on the tool's working directory.

```sh
sh -c 'f="$CLAUDE_PROJECT_DIR/.claude/hooks/<hook>.cjs"; [ ! -f "$f" ] || node "$f"'
```

Guarded **4** hook command(s) in `.claude/settings.json`.

Closes #160