### PR TITLE
chore(ci): pin third-party actions by commit SHA

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -5,5 +5,5 @@ jobs:
     name: Check PR dependencies
     runs-on: ubuntu-latest
     steps:
-    - uses: gregsdennis/dependencies-action@v1.4.2
+    - uses: gregsdennis/dependencies-action@a8cccab69814b9b985496cf97cbfe154c96c03c7 # v1.4.2
 name: Dependencies

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Build site
       run: mkdocs build
     - name: Deploy to GitHub Pages
-      uses: peaceiris/actions-gh-pages@v4.1.0
+      uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: site

--- a/.github/workflows/pr-dependencies.yml
+++ b/.github/workflows/pr-dependencies.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
     - env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      uses: gregsdennis/dependencies-action@v1.4.2
+      uses: gregsdennis/dependencies-action@a8cccab69814b9b985496cf97cbfe154c96c03c7 # v1.4.2
     - uses: Levi-Lesches/blocking-issues@2eeffdc6b055341f635eb0f3e4aea671516a61dc
       with:
         use-label: Blocked

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,14 +17,14 @@ jobs:
         fetch-depth: 0
         token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
     - name: Setup GitVersion
-      uses: gittools/actions/gitversion/setup@v4.7.0
+      uses: gittools/actions/gitversion/setup@7417b1089e2c7de93510f1901d656ddf60bb024f # v4.7.0
       with:
         versionSpec: 6.x
     - id: gitversion
       name: Determine version
-      uses: gittools/actions/gitversion/execute@v4.7.0
+      uses: gittools/actions/gitversion/execute@7417b1089e2c7de93510f1901d656ddf60bb024f # v4.7.0
     - name: Install git-cliff
-      uses: taiki-e/install-action@git-cliff
+      uses: taiki-e/install-action@e215f18e24d7f4b411833009234c054235f9447f # git-cliff
     - id: changelog
       name: Generate changelog
       run: "CURRENT_TAG=\"v${{ steps.gitversion.outputs.semVer }}\"\ngit cliff --output\
@@ -43,7 +43,7 @@ jobs:
 
         '
     - name: Create GitHub Release
-      uses: softprops/action-gh-release@v3.0.2
+      uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
       with:
         body_path: CHANGELOG_RELEASE.md
         name: Release ${{ steps.changelog.outputs.version }}


### PR DESCRIPTION
Applies the fleet GitHub Actions standard: **third-party actions are pinned by commit
SHA**, with the version kept in a trailing comment. `actions/*` and `chrysa/*` stay on tags.

A mutable tag or branch means the code executing in CI — with the workflow token — can change
under you without a diff. Found by a fleet-wide audit (87 unpinned references across 63 repos);
the copies distributed from `shared-standards` were fixed at the source in shared-standards#289,
this PR covers the workflows this repo owns.

Pinned here:

- `gittools/actions/gitversion/execute` `v4.7.0` → `7417b1089e2c`
- `gittools/actions/gitversion/setup` `v4.7.0` → `7417b1089e2c`
- `gregsdennis/dependencies-action` `v1.4.2` → `a8cccab69814`
- `peaceiris/actions-gh-pages` `v4.1.0` → `84c30a85c199`
- `softprops/action-gh-release` `v3.0.2` → `3d0d9888cb7f`
- `taiki-e/install-action` `git-cliff` → `e215f18e24d7`
