### PR TITLE
chore: sync chrysa shared standards

### DIFF
--- a/.claude/skills/ui-ux/SKILL.md
+++ b/.claude/skills/ui-ux/SKILL.md
@@ -15,7 +15,7 @@ Auto-invoke when building or reviewing ANY human-facing surface, not only web:
 - **CLI/TUI**: commands, flags, help, output, exit codes.
 - **VS Code extension**: commands, webviews, theming, notifications.
 - **Discord bot**: slash commands, embeds, interactive components.
-- **Desktop/tray**: native apps, system tray, notifications (windows-autonome, floating-agent…).
+- **Desktop/tray**: native apps, system tray, notifications (workstation-os, floating-agent…).
 - **Game UI (2D)**: HUD, menus, input remapping (Discordium…).
 - **Agent/conversational**: assistant/agent responses (lifeos, my-assistant, coach…).
 - **Alerts/notifications**: briefing/health/state alerts.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,6 +199,18 @@ deprecated and archived — nothing is added to it, nothing reads from it.
   and a documented idempotency/timeout/limits/circuit-breaker/rollback envelope. Untrusted
   execution is sandboxed with network off by default; no agent auto-merges to `main`.
   Detail: annexe `AGENTIC-CAPABILITIES.md`.
+- **An agent writes only where the owner owns.** An AI agent may open issues, pull requests,
+  comments, branches and releases **only on repositories the owner owns** — the `chrysa`
+  account and the organisations under the owner's control. On any third-party repository
+  (an upstream project, a dependency, a fork's source, a client's repo) an agent **does not
+  file an issue, does not comment, does not open a PR**: it drafts the content locally and
+  hands it to the owner, who decides whether and how to send it. This is not a permissions
+  detail — an issue is a **public act under a human's name**, and a wrong or noisy one costs
+  reputation in a community the agent cannot read. The same limit applies to any outward
+  channel an agent could reach (email, chat, social, package registries): drafting is free,
+  publishing outside the owner's own perimeter is the owner's call. Inside the perimeter,
+  the normal rules still hold — one issue per real problem, no duplicate of an open one, and
+  every PR references its issue.
 - **Projects talk through versioned contracts only.** No import from a sibling repo, no path
   dependency, no submodule used as a runtime link, no access to another project's database or
   private models. Each consumer wraps the external contract in a local adapter and degrades


### PR DESCRIPTION
Automated distribution of chrysa shared standards.

**Source:** `chrysa/shared-standards@d2dd6bd24b811855ed61f4826509e2875b32999b`
Managed files (inline transverse standards block in `CLAUDE.md`,
shared skills/agents/commands, CI workflows, lint/quality, pre-commit)
were refreshed by `scripts/distribute-standards.sh`.

Review the diff: repo-specific content is preserved; only managed,
delimited blocks and shared files are updated.

Refs: chrysa/shared-standards