### PR TITLE
ci: concurrency group and job timeouts (annexe CI-030, CI-031)

### DIFF
--- a/.github/workflows/action-check.yml
+++ b/.github/workflows/action-check.yml
@@ -11,8 +11,8 @@
     paths:
     - .github/workflows/**
 concurrency:
-    group: ${{ github.workflow }}-${{ github.ref }}
-    cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   actionlint:

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -5,8 +5,8 @@
     - ready_for_review
     - reopened
 concurrency:
-    group: ${{ github.workflow }}-${{ github.ref }}
-    cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   add-reviews:

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -1,8 +1,8 @@
 on:
   pull_request: null
 concurrency:
-    group: ${{ github.workflow }}-${{ github.ref }}
-    cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   dependencies:

--- a/.github/workflows/enforce-feature-branch.yml
+++ b/.github/workflows/enforce-feature-branch.yml
@@ -6,8 +6,8 @@ on:
     - reopened
     - synchronize
 concurrency:
-    group: ${{ github.workflow }}-${{ github.ref }}
-    cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   branch-policy:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -3,8 +3,8 @@
   workflow_call: null
   workflow_dispatch: null
 concurrency:
-    group: ${{ github.workflow }}-${{ github.ref }}
-    cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   labels:

--- a/.github/workflows/pr-dependencies.yml
+++ b/.github/workflows/pr-dependencies.yml
@@ -15,8 +15,8 @@
   workflow_call: null
   workflow_dispatch: null
 concurrency:
-    group: ${{ github.workflow }}-${{ github.ref }}
-    cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   check_dependencies:

--- a/.github/workflows/quality-gate-check.yml
+++ b/.github/workflows/quality-gate-check.yml
@@ -13,8 +13,8 @@ on:
     - main
     - master
 concurrency:
-    group: ${{ github.workflow }}-${{ github.ref }}
-    cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   quality-gate:

--- a/.github/workflows/update-pr-body.yml
+++ b/.github/workflows/update-pr-body.yml
@@ -4,8 +4,8 @@
     - opened
     - synchronize
 concurrency:
-    group: ${{ github.workflow }}-${{ github.ref }}
-    cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   update-body:


### PR DESCRIPTION
Applies the two deterministic rules of annexe [`CI-CD.md`](https://github.com/chrysa/shared-standards/blob/main/standards/annexes/CI-CD.md):

- **CI-030** — every job declares `timeout-minutes:` (set to 30, raise it where the job legitimately runs longer). Without it a hung job holds a runner until the platform cap.
- **CI-031** — every PR-triggered workflow declares a concurrency group. Superseded PR runs are cancelled; **deploy and release workflows queue instead** (`cancel-in-progress: false`) — cancelling a deployment mid-flight is worse than queueing it.

The remaining findings (permissions, `secrets: inherit`, action pinning) are judgement calls and are reported by `scripts/ci_annexe_audit.py`, never guessed.