### PR TITLE
chore: sync chrysa shared standards

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,6 +42,7 @@ repos:
     exclude: (^|/)tests?/
   - id: python-mutable-default
   - id: python-dispatch-ladder
+  - id: dockerfile-no-latest
   repo: https://github.com/chrysa/pre-commit-tools
   rev: v0.2.0-247
 - hooks:


### PR DESCRIPTION
Automated distribution of chrysa shared standards.

**Source:** `chrysa/shared-standards@18733daebdd5ec1131268ccc7e462512178e9078`
Managed files (inline transverse standards block in `CLAUDE.md`,
shared skills/agents/commands, CI workflows, lint/quality, pre-commit)
were refreshed by `scripts/distribute-standards.sh`.

Review the diff: repo-specific content is preserved; only managed,
delimited blocks and shared files are updated.

Refs: chrysa/shared-standards