### PR TITLE
ci: pin third-party actions by commit SHA (CI-010)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 20
         steps:
-            - uses: actions/checkout@v7.0.1
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             - name: Run tests via Docker
               run: make docker-test
@@ -62,7 +62,7 @@ jobs:
             # sonar-scan-python downloads into reports/.
             - name: Upload coverage report
               if: always()
-              uses: actions/upload-artifact@v7
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
               with:
                   name: test-results-3.14
                   path: coverage.xml
@@ -78,7 +78,7 @@ jobs:
             contents: read
             pull-requests: read
         steps:
-            - uses: actions/checkout@v7.0.1
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                   fetch-depth: 0
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -14,9 +14,9 @@ jobs:
     name: Build and deploy docs
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7.0.1
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Set up Python 3.14
-      uses: actions/setup-python@v7.0.0
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: '3.14'
     - name: Install MkDocs

--- a/.github/workflows/quality-gate-check.yml
+++ b/.github/workflows/quality-gate-check.yml
@@ -23,14 +23,14 @@ jobs:
     timeout-minutes: 30
     steps:
     - name: Checkout code
-      uses: actions/checkout@v7.0.1
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Set up Python
-      uses: actions/setup-python@v7.0.0
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: '3.14'
     - continue-on-error: true
       name: Set up Node.js (if needed)
-      uses: actions/setup-node@v7.0.0
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         cache: npm
         node-version: '20'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-    - uses: actions/checkout@v7.0.1
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0
         token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -29,7 +29,7 @@ jobs:
         timeout-minutes: 15
         steps:
             - name: Checkout
-              uses: actions/checkout@v7.0.1
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                   fetch-depth: 0
             - name: SonarCloud scan


### PR DESCRIPTION
Third-party actions are now pinned by 40-character commit SHA, with the version kept in a trailing comment (annexe [`CI-010`](https://github.com/chrysa/shared-standards/blob/main/standards/annexes/CI-CD.md)).

A tag is a **mutable pointer**: whoever owns the action can move it, and every workflow referencing it then runs different code — with this repository's token in scope. Pinning by SHA is what makes a supply-chain change visible in a diff instead of silent.

Each SHA was resolved from the GitHub API, never guessed. Left alone on purpose: `chrysa/*` actions (`CI-011` pins those by tag so the fleet moves deliberately), local `./.github/actions/…` references, and branch refs — freezing a moving target at an arbitrary tip is a decision, not a mechanical fix.

The trailing comment keeps Dependabot able to bump these.