### PR TITLE
chore(pre-commit): align print/pprint policy excludes to shared baseline

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,102 +4,102 @@ exclude: ^\.claude/
 fail_fast: false
 minimum_pre_commit_version: 4.1.0
 repos:
-- hooks:
-  - id: ruff
-  - id: ruff-format
-  repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.16.0
-- hooks:
-  - id: makefile-check
-  - id: python-unreachable-code
-  - id: no-bare-except
-  - id: adr-gate
-  - id: python-print-detection
-    exclude: (^|/)tests?/|^(README\.md|docs/)
-  - id: python-pprint-detection
-    exclude: (^|/)tests?/|^(README\.md|docs/)
-  - id: python-logger-detection
-    exclude: (^|/)tests?/|^(README\.md|docs/)
-  - id: no-sync-in-async
-  - id: debugger-detection
-    exclude: (^|/)tests?/|^(README\.md|docs/)
-  - id: regression-gate
-    stages:
-    - pre-push
-  - exclude: ^(\.github/|workflows/|templates/)
-    id: yaml-sorter
-  - id: json-sorter
-  - id: env-file-check
-  - id: env-example-sync
-  - exclude: tests?/|\.test\.|\.spec\.
-    id: no-hardcoded-localhost
-  - id: claude-skill-frontmatter
-  - id: claude-agent-frontmatter
-  - id: claude-mcp-config
-  - id: python-no-unittest-import
-  - id: claude-assets-present
-  - id: python-untyped-raise
-    exclude: (^|/)tests?/
-  - id: python-mutable-default
-  - id: python-dispatch-ladder
-  - id: dockerfile-no-latest
-  repo: https://github.com/chrysa/pre-commit-tools
-  rev: v0.2.0-253
-- hooks:
-  - id: detect-private-key
-  - id: no-commit-to-branch
-  - id: trailing-whitespace
-  - id: end-of-file-fixer
-  - id: check-yaml
-  - id: check-json
-  - id: check-toml
-  - id: check-merge-conflict
-  - id: check-added-large-files
-  - id: mixed-line-ending
-  repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v6.0.0
-- hooks:
-  - args:
-    - --strict
-    id: yamllint
-  repo: https://github.com/adrienverge/yamllint
-  rev: v1.38.0
-- hooks:
-  - args:
-    - feat
-    - fix
-    - docs
-    - style
-    - refactor
-    - test
-    - chore
-    - perf
-    - revert
-    - ci
-    id: conventional-pre-commit
-    stages:
-    - commit-msg
-  repo: https://github.com/compilerla/conventional-pre-commit
-  rev: v4.4.0
-- hooks:
-  - args:
-    - --fix
-    id: markdownlint
-    stages:
-    - manual
-  repo: https://github.com/igorshubovych/markdownlint-cli
-  rev: v0.49.1
-- hooks:
-  - id: gitleaks
-  repo: https://github.com/gitleaks/gitleaks
-  rev: v8.30.1
-- hooks:
-  - args:
-    - check
-    - --fail-on
-    - error
-    - --baseline
-    - .guideline-baseline.json
-    id: guideline-check
-  repo: https://github.com/chrysa/guideline-checker
-  rev: v1.30.10
+  - hooks:
+      - id: ruff
+      - id: ruff-format
+    repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.16.0
+  - hooks:
+      - id: makefile-check
+      - id: python-unreachable-code
+      - id: no-bare-except
+      - id: adr-gate
+      - id: python-print-detection
+        exclude: '(^|/)tests?/|^(README\.md|docs/)|(^|/)quality_gate\.py$|^\.claude/ape/'
+      - id: python-pprint-detection
+        exclude: '(^|/)tests?/|^(README\.md|docs/)|(^|/)quality_gate\.py$|^\.claude/ape/'
+      - id: python-logger-detection
+        exclude: '(^|/)tests?/|^(README\.md|docs/)'
+      - id: no-sync-in-async
+      - id: debugger-detection
+        exclude: '(^|/)tests?/|^(README\.md|docs/)'
+      - id: regression-gate
+        stages:
+          - pre-push
+      - exclude: ^(\.github/|workflows/|templates/)
+        id: yaml-sorter
+      - id: json-sorter
+      - id: env-file-check
+      - id: env-example-sync
+      - exclude: tests?/|\.test\.|\.spec\.
+        id: no-hardcoded-localhost
+      - id: claude-skill-frontmatter
+      - id: claude-agent-frontmatter
+      - id: claude-mcp-config
+      - id: python-no-unittest-import
+      - id: claude-assets-present
+      - id: python-untyped-raise
+        exclude: '(^|/)tests?/'
+      - id: python-mutable-default
+      - id: python-dispatch-ladder
+      - id: dockerfile-no-latest
+    repo: https://github.com/chrysa/pre-commit-tools
+    rev: v0.2.0-253
+  - hooks:
+      - id: detect-private-key
+      - id: no-commit-to-branch
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-json
+      - id: check-toml
+      - id: check-merge-conflict
+      - id: check-added-large-files
+      - id: mixed-line-ending
+    repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+  - hooks:
+      - args:
+          - --strict
+        id: yamllint
+    repo: https://github.com/adrienverge/yamllint
+    rev: v1.38.0
+  - hooks:
+      - args:
+          - feat
+          - fix
+          - docs
+          - style
+          - refactor
+          - test
+          - chore
+          - perf
+          - revert
+          - ci
+        id: conventional-pre-commit
+        stages:
+          - commit-msg
+    repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v4.4.0
+  - hooks:
+      - args:
+          - --fix
+        id: markdownlint
+        stages:
+          - manual
+    repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.49.1
+  - hooks:
+      - id: gitleaks
+    repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+  - hooks:
+      - args:
+          - check
+          - --fail-on
+          - error
+          - --baseline
+          - .guideline-baseline.json
+        id: guideline-check
+    repo: https://github.com/chrysa/guideline-checker
+    rev: v1.30.10


### PR DESCRIPTION
Aligns `python-print-detection` + `python-pprint-detection` policy excludes to the shared-standards baseline (adds `quality_gate.py` + `.claude/ape/`). Fleet standards sync via pre-commit-merge.py.